### PR TITLE
fix(docs): correct MkDocs server URL path in workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -116,9 +116,6 @@ jobs:
 
       - name: Test internal links
         run: |
-          # Install link checker
-          pip install pytest-html-report
-
           # Start local server in background
           mkdocs serve &
           SERVER_PID=$!
@@ -126,8 +123,8 @@ jobs:
           # Wait for server to start
           sleep 5
 
-          # Test that server is running
-          curl -f http://localhost:8000/ || exit 1
+          # Test that server is running (MkDocs serves with site_url path)
+          curl -f http://localhost:8000/safe-job/ || exit 1
 
           # Kill server
           kill $SERVER_PID


### PR DESCRIPTION
## 📋 Summary

Fixes the documentation workflow failure by correcting the MkDocs server URL path in the internal links test.

## 🐛 Problem

The documentation workflow was failing because it was trying to test  but MkDocs serves the site at  due to the  configuration in .

## 🔧 Solution

- Updated the internal links test to use the correct URL: 
- Removed unnecessary  dependency
- Cleaned up the test script

## 🧪 Testing

This will fix the failing documentation deployment workflow that was preventing the main PR from being merged.

## 📚 Documentation

- [x] No documentation changes needed - this is a workflow fix

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>